### PR TITLE
fix: UnitSystem changes in integrations.library

### DIFF
--- a/dependencies.cfg
+++ b/dependencies.cfg
@@ -3,4 +3,4 @@
 #   name: dependency name
 #   separator: colon + optional white space
 #   version: git branch or tag
-integrations.library: v0.4.3
+integrations.library: qml-enums

--- a/dependencies.cfg
+++ b/dependencies.cfg
@@ -3,4 +3,4 @@
 #   name: dependency name
 #   separator: colon + optional white space
 #   version: git branch or tag
-integrations.library: qml-enums
+integrations.library: v0.5.0

--- a/openweather.json.in
+++ b/openweather.json.in
@@ -30,7 +30,7 @@
   ],
   \"url\": \"https://github.com/YIO-Remote/integration.openweather\",
   \"dependencies\" : [
-      { \"name\" : \"app\", \"version\" : \"0.2.0\" },
+      { \"name\" : \"app\", \"version\" : \"0.5.0\" },
       { \"name\" : \"remoteOS\", \"version\" : \"0.2.0\" }
   ]
 }

--- a/openweather.pro
+++ b/openweather.pro
@@ -43,10 +43,13 @@ isEmpty(INTG_LIB_PATH) {
 unix {
     INTG_LIB_VERSION = $$system(cat $$PWD/dependencies.cfg | awk '/^integrations.library:/$$system_quote("{print $2}")')
     INTG_GIT_VERSION = "$$system(cd $$INTG_LIB_PATH && git describe --match "v[0-9]*" --tags HEAD --always)"
-    message("Required integrations.library version: $$INTG_LIB_VERSION Local version: $$INTG_GIT_VERSION")
+    INTG_GIT_BRANCH  = "$$system(cd $$INTG_LIB_PATH && git rev-parse --abbrev-ref HEAD)"
+    message("Required integrations.library version: $$INTG_LIB_VERSION Local version: $$INTG_GIT_VERSION ($$INTG_GIT_BRANCH)")
     # this is a simple check but qmake only provides limited tests and 'versionAtLeast' doesn't work with 'v' prefix.
-    !contains(INTG_GIT_VERSION, $$re_escape($${INTG_LIB_VERSION}).*) {
-        error("Invalid integrations.library version: \"$$INTG_GIT_VERSION\". Please check out required version \"$$INTG_LIB_VERSION\"")
+    !contains(INTG_GIT_VERSION, $$re_escape($${INTG_LIB_VERSION}).*)) {
+        !equals(INTG_GIT_BRANCH, $$INTG_LIB_VERSION) {
+            error("Invalid integrations.library version: \"$$INTG_GIT_VERSION\". Please check out required version \"$$INTG_LIB_VERSION\"")
+        }
     }
 }
 

--- a/src/OpenWeather.cpp
+++ b/src/OpenWeather.cpp
@@ -245,7 +245,7 @@ OpenWeather::OpenWeather(const QString& apiUrl, const QString& iconUrl, const QS
       _imageCache(_iconUrl, cacheDirectory, m_logCategory, true),
       _nam(this) {
 
-    if (configObj->getUnitSystem() == ConfigInterface::IMPERIAL) {
+    if (configObj->getUnitSystem() == UnitSystem::IMPERIAL) {
         _units = "imperial";
         _imperial = true;
     }


### PR DESCRIPTION
PR YIO-Remote/remote-software#476 must be merged first. The corresponding release version of integrations.library must be set in dependencies.cfg before this PR is merged!

Part of YIO-Remote/remote-software#473